### PR TITLE
Fixed docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo "$0: Starting SQL Server"
-docker-entrypoint-initdb.sh & /opt/mssql/bin/sqlservr.sh
+docker-entrypoint-initdb.sh & /opt/mssql/bin/sqlservr


### PR DESCRIPTION
Fixed docker-entrypoint.sh to make it work against latest microsoft/mssql-server-linux base image.